### PR TITLE
Added: Added game setting to enable verbose logging

### DIFF
--- a/Source/ROLib/ModelDef/ROLModelData.cs
+++ b/Source/ROLib/ModelDef/ROLModelData.cs
@@ -23,7 +23,10 @@ namespace ROLib
             foreach (ConfigNode node in modelDatas)
             {
                 data = new ROLModelDefinition(node);
-                ROLLog.log("Loading model definition data for name: " + data.name + " with model URL: " + data.modelName);
+                if (ROLGameSettings.LoggingEnabled)
+                {
+                    ROLLog.log("Loading model definition data for name: " + data.name + " with model URL: " + data.modelName);
+                }
                 if (baseModelData.ContainsKey(data.name))
                 {
                     ROLLog.error("Model defs already contains def for name: " + data.name + ".  Please check your configs as this is an error.  The duplicate entry was found in the config node of:\n"+node);

--- a/Source/ROLib/ModelDef/ROLModelLayout.cs
+++ b/Source/ROLib/ModelDef/ROLModelLayout.cs
@@ -14,7 +14,10 @@ namespace ROLib
 
         public static void load()
         {
-            ROLLog.log("Loading Model Layouts");
+            if (ROLGameSettings.LoggingEnabled)
+            {
+                ROLLog.log("Loading Model Layouts");
+            }
             layouts.Clear();
             ConfigNode[] layoutNodes = GameDatabase.Instance.GetConfigNodes("ROL_MODEL_LAYOUT");
             int len = layoutNodes.Length;
@@ -24,7 +27,10 @@ namespace ROLib
                 layouts.Add(mld.name, mld);
             }
             loaded = true;
-            ROLLog.log("Finished loading Model Layouts");
+            if (ROLGameSettings.LoggingEnabled)
+            {
+                ROLLog.log("Finished loading Model Layouts");
+            }
         }
 
         public static ModelLayoutData findLayout(string name)

--- a/Source/ROLib/Modules/ModuleROTank.cs
+++ b/Source/ROLib/Modules/ModuleROTank.cs
@@ -103,7 +103,10 @@ namespace ROLib
         [KSPEvent(guiName = "Open Diameter Selection", guiActiveEditor = true, groupName = GroupName)]
         public void OpenTankDimensionGUIEvent()
         {
-            ROLLog.debug("EditDimensions() called");
+            if (ROLGameSettings.LoggingEnabled)
+            {
+                ROLLog.debug("EditDimensions() called");
+            }
             EditDimensions(this);
         }
 
@@ -680,7 +683,10 @@ namespace ROLib
             float noseMaxDiam = Math.Max(noseModule.moduleLowerDiameter, noseModule.moduleUpperDiameter);
             totalTankLength = GetTotalHeight();
             largestDiameter = Math.Max(currentDiameter, Math.Max(noseMaxDiam, mountMaxDiam));
-            ROLLog.debug($"UpdateDimensions() currentMount: {currentMount}  Largest Diameter: {largestDiameter}.  Total Tank length: {totalTankLength}");
+            if (ROLGameSettings.LoggingEnabled)
+            {
+                ROLLog.debug($"UpdateDimensions() currentMount: {currentMount}  Largest Diameter: {largestDiameter}.  Total Tank length: {totalTankLength}");
+            }
         }
 
         /// <summary>
@@ -774,7 +780,10 @@ namespace ROLib
 
             string ratioName = $"{modelRatio:0.0}";
             string s = $"{ratioName}x-{currentVariant}";
-            ROLLog.debug($"dimRatio: {dimRatio}, modelRatio: {modelRatio}, {ratioName}x-{currentVariant}");
+            if (ROLGameSettings.LoggingEnabled)
+            {
+                ROLLog.debug($"dimRatio: {dimRatio}, modelRatio: {modelRatio}, {ratioName}x-{currentVariant}");
+            }
 
             currentVScale = (dimRatio / modelRatio) - 1;
             coreModule.modelSelected(s);

--- a/Source/ROLib/Modules/ROLSelectableNodes.cs
+++ b/Source/ROLib/Modules/ROLSelectableNodes.cs
@@ -92,7 +92,10 @@ namespace ROLib
         public void toggleNode()
         {
             AttachNode node = part.FindAttachNode(nodeName);
-            ROLLog.debug("toggleNode() node: " + node);
+            if (ROLGameSettings.LoggingEnabled)
+            {
+                ROLLog.debug("toggleNode() node: " + node);
+            }
             if (node == null)
             {
                 currentlyEnabled = true;

--- a/Source/ROLib/ROSolar/SolarTechLimit.cs
+++ b/Source/ROLib/ROSolar/SolarTechLimit.cs
@@ -41,12 +41,18 @@ namespace ROLib
         {
             if (!isInitialized)
             {
-                ROLLog.debug($"{modTag}: Init()");
+                if (ROLGameSettings.LoggingEnabled)
+                {
+                    ROLLog.debug($"{modTag}: Init()");
+                }
                 allTL.Clear();
                 foreach (ConfigNode node in config.GetNodes("ROS_TECH"))
                 {
                     SolarTechLimit obj = ConfigNode.CreateObjectFromConfig<SolarTechLimit>(node);
-                    ROLLog.debug($"{modTag}: Adding ROSTL {obj}");
+                    if (ROLGameSettings.LoggingEnabled)
+                    {
+                        ROLLog.debug($"{modTag}: Adding ROSTL {obj}");
+                    }
                     allTL.Add(obj.level, obj);
                     maxTL = Math.Max(maxTL, obj.level);
                 }

--- a/Source/ROLib/UI/DimensionWindow.cs
+++ b/Source/ROLib/UI/DimensionWindow.cs
@@ -230,7 +230,10 @@ namespace ROLib
             fld.uiControlEditor.onFieldChanged.Invoke(fld, oldDiameter);
 
             MonoUtilities.RefreshContextWindows(module.part);
-            ROLLog.log("ModuleROTank - Diameter set to: " + f);
+            if (ROLGameSettings.LoggingEnabled)
+            {
+                ROLLog.log("ModuleROTank - Diameter set to: " + f);
+            }
         }
 
         public override void Window(int id)

--- a/Source/ROLib/Utils/ROLGameSettings.cs
+++ b/Source/ROLib/Utils/ROLGameSettings.cs
@@ -8,8 +8,9 @@ namespace ROLib
         [GameParameters.CustomParameterUI("Persistent Recolor Selections", toolTip = "If true, custom recolor selections will persist across texture set changes.")]
         public bool persistRecolorSelections = false;
 
-        [GameParameters.CustomParameterUI("Enable Verbose Llogging", toolTip = "Additional Verbose logging can help when troubleshooting, but also reduces performance.")]
+        [GameParameters.CustomParameterUI("Enable Verbose Logging", toolTip = "Additional Verbose logging can help when troubleshooting, but also reduces performance.")]
         public bool enabledDebugLogging = false;
+        
         public override string Section { get { return "RO Mods Settings"; } }
 
         public override int SectionOrder { get { return 1; } }

--- a/Source/ROLib/Utils/ROLGameSettings.cs
+++ b/Source/ROLib/Utils/ROLGameSettings.cs
@@ -8,6 +8,8 @@ namespace ROLib
         [GameParameters.CustomParameterUI("Persistent Recolor Selections", toolTip = "If true, custom recolor selections will persist across texture set changes.")]
         public bool persistRecolorSelections = false;
 
+        [GameParameters.CustomParameterUI("Enable Verbose Llogging", toolTip = "Additional Verbose logging can help when troubleshooting, but also reduces performance.")]
+        public bool enabledDebugLogging = false;
         public override string Section { get { return "RO Mods Settings"; } }
 
         public override int SectionOrder { get { return 1; } }
@@ -52,6 +54,18 @@ namespace ROLib
                 return HighLogic.CurrentGame.Parameters.CustomParams<ROLGameSettings>().persistRecolorSelections;
             }
             return false;
+        }
+
+        public static bool LoggingEnabled
+        {
+            get
+            {
+                if (HighLogic.CurrentGame != null)
+                {
+                    return HighLogic.CurrentGame.Parameters.CustomParams<ROLGameSettings>().enabledDebugLogging;
+                }
+                return false;
+            }
         }
 
     }


### PR DESCRIPTION
Added a new setting for verbose logging in the game settings.  Defaults to FALSE.

Wrapped calls to ROLLog.log and ROLLog.debug up in a check against the user's verbose log setting and only do the logging if set.

Logging has a performance hit, and even preparing a string to log can cause boxing and allocations.  This small cleanup won't make a huge difference with so many mods but its a start and the right way to do it :)