### PR TITLE
Add ROLAnimateEngineHeat

### DIFF
--- a/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
+++ b/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
@@ -102,14 +102,12 @@ namespace ROLib
         private void locateEngineModule()
         {
             engineModule = null;
-            ModuleEngines[] engines = part.GetComponents<ModuleEngines>();
-            int len = engines.Length;
             engineModule = part.GetComponents<ModuleEngines>().FirstOrDefault(x => x.engineID == engineID);
             if (engineModule == null)
-            {
-                MonoBehaviour.print("ERROR: Could not locate engine by ID: " + engineID + " for part: " + part + " for ROLAnimateEngineHeat.  This will cause errors during gameplay.  Setting engine to first engine module (if present)");
-                if (engines.Length > 0) { engineModule = engines[0]; }
-            }
+                MonoBehaviour.print("ERROR: Could not locate engine by ID: " + engineID + " for part: " + part +
+                                    " for ROLAnimateEngineHeat.  This will cause errors during gameplay.  Setting engine to first engine module (if present)");
+
+            engineModule ??= part.GetComponent<ModuleEngines>();
         }
 
         private void locateAnimatedTransforms()

--- a/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
+++ b/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ROLib
+{
+    public class ROLAnimateEngineHeat : PartModule
+    {
+
+        //amount of 'heat' added per second at full throttle
+        [KSPField]
+        public float heatOutput = 300;
+
+        //amount of heat dissipated per second, adjusted by the heatDissipationCurve below
+        [KSPField]
+        public float heatDissipation = 100;
+
+        //point at which the object will begin to glow
+        [KSPField]
+        public float draperPoint = 400;
+
+        //maximum amount of heat allowed in this engine
+        //will reach max glow at this temp, and begin dissipating even faster past this point
+        [KSPField]
+        public float maxHeat = 2400;
+
+        //maxStoredHeat
+        //storedHeat will not go beyond this, sets retention period for maximum glow
+        [KSPField]
+        public float maxStoredHeat = 3600;
+
+        //curve to adjust heat dissipation; should generally expel heat faster when hotter
+        [KSPField]
+        public FloatCurve heatDissipationCurve = new FloatCurve();
+
+        //the heat-output curve for an engine (varies with thrust/throttle), in case it is not linear
+        [KSPField]
+        public FloatCurve heatAccumulationCurve = new FloatCurve();
+
+        [KSPField]
+        public FloatCurve redCurve = new FloatCurve();
+
+        [KSPField]
+        public FloatCurve blueCurve = new FloatCurve();
+
+        [KSPField]
+        public FloatCurve greenCurve = new FloatCurve();
+
+        [KSPField]
+        public string engineID = "Engine";
+
+        [KSPField]
+        public String meshName = String.Empty;
+
+        [KSPField(isPersistant = true)]
+        public float currentHeat = 0;
+
+        [KSPField]
+        public bool useThrottle;
+
+        int shaderEmissiveID;
+
+        private ModuleEngines engineModule;
+
+        private Renderer[] animatedRenderers;
+
+        private Color emissiveColor = new Color(0f, 0f, 0f, 1f);
+
+        public override void OnAwake()
+        {
+            base.OnAwake();
+            heatDissipationCurve.Add(0f, 0.2f);
+            heatDissipationCurve.Add(1f, 1f);
+
+            heatAccumulationCurve.Add(0f, 0f);
+            heatAccumulationCurve.Add(1f, 1f);
+            
+            redCurve.Add(0f, 0f);
+            redCurve.Add(1f, 1f);
+
+            blueCurve.Add(0f, 0f);
+            blueCurve.Add(1f, 1f);
+
+            greenCurve.Add(0f, 0f);
+            greenCurve.Add(1f, 1f);
+
+            shaderEmissiveID = Shader.PropertyToID("_EmissiveColor");
+        }
+
+        public override void OnStart(StartState state)
+        {
+            base.OnStart(state);
+            initialize();
+        }
+
+        public void FixedUpdate()
+        {
+            if (!HighLogic.LoadedSceneIsFlight) { return; }
+            updateHeat();
+        }
+
+        private void initialize()
+        {
+            locateAnimatedTransforms();
+            locateEngineModule();
+        }
+
+        public void reInitialize()
+        {
+            animatedRenderers = null;
+            engineModule = null;
+            initialize();
+        }
+
+        private void locateEngineModule()
+        {
+            engineModule = null;
+            ModuleEngines[] engines = part.GetComponents<ModuleEngines>();
+            int len = engines.Length;
+            for (int i = 0; i < len; i++)
+            {
+                if (engines[i].engineID == engineID)
+                {
+                    engineModule = engines[i];
+                }
+            }
+            if (engineModule == null)
+            {
+                MonoBehaviour.print("ERROR: Could not locate engine by ID: " + engineID + " for part: " + part + " for ROLAnimateEngineHeat.  This will cause errors during gameplay.  Setting engine to first engine module (if present)");
+                if (engines.Length > 0) { engineModule = engines[0]; }
+            }
+        }
+
+        private void locateAnimatedTransforms()
+        {
+            List<Renderer> renderers = new List<Renderer>();
+            Transform[] animatedTransforms = part.transform.ROLFindChildren(meshName);
+            int len = animatedTransforms.Length;
+            for (int i = 0; i < len; i++)
+            {
+                renderers.AddRange(animatedTransforms[i].GetComponentsInChildren<Renderer>(false));
+            }
+            animatedRenderers = renderers.ToArray();
+            if (animatedRenderers == null || animatedRenderers.Length == 0) { print("ERROR: Could not locate any emissive meshes for name: " + meshName); }
+        }
+
+        private void updateHeat()
+        {
+            if (engineModule == null) { return; }
+
+            float emissivePercent = 0f;
+
+            if (!useThrottle)
+            {
+                //add heat from engine
+                if (engineModule.EngineIgnited && !engineModule.flameout && engineModule.currentThrottle > 0)
+                {
+                    float throttle = engineModule.currentThrottle;
+                    float heatIn = heatAccumulationCurve.Evaluate(throttle) * heatOutput * TimeWarp.fixedDeltaTime;
+                    currentHeat += heatIn;
+                }
+
+                //dissipate heat
+                float heatPercent = currentHeat / maxHeat;
+                if (currentHeat > 0f)
+                {
+                    float heatOut = heatDissipationCurve.Evaluate(heatPercent) * heatDissipation * TimeWarp.fixedDeltaTime;
+                    if (heatOut > currentHeat) { heatOut = currentHeat; }
+                    currentHeat -= heatOut;
+                }
+                if (currentHeat > maxStoredHeat) { currentHeat = maxStoredHeat; }
+
+                float mhd = maxHeat - draperPoint;
+                float chd = currentHeat - draperPoint;
+
+                if (chd < 0f) { chd = 0f; }
+                emissivePercent = chd / mhd;
+            }
+            else
+            {
+                emissivePercent = engineModule.currentThrottle;
+            }
+
+
+            if (emissivePercent > 1f) { emissivePercent = 1f; }
+            emissiveColor.r = redCurve.Evaluate(emissivePercent);
+            emissiveColor.g = greenCurve.Evaluate(emissivePercent);
+            emissiveColor.b = blueCurve.Evaluate(emissivePercent);
+            setEmissiveColors();
+        }
+
+        private void setEmissiveColors()
+        {
+            if (animatedRenderers != null)
+            {
+                bool rebuild = false;
+                int len = animatedRenderers.Length;
+                for (int i = 0; i < len; i++)
+                {
+                    if (animatedRenderers[i] == null)
+                    {
+                        rebuild = true;
+                        continue;
+                    }
+                    animatedRenderers[i].sharedMaterial.SetColor(shaderEmissiveID, emissiveColor);
+                }
+                if (rebuild)
+                {
+                    animatedRenderers = null;
+                    locateAnimatedTransforms();
+                }
+            }
+        }
+
+    }
+}

--- a/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
+++ b/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
@@ -70,7 +70,7 @@ namespace ROLib
 
         private Func<double> getSolverChamberTemp;
 
-        private bool useSolverEngines = false;
+        public bool useSolverEngines => getSolverChamberTemp != null;
 
         public override void OnAwake()
         {
@@ -131,16 +131,12 @@ namespace ROLib
 
         private void locateSolverEngines()
         {
-            ModuleEngines solverEnginesModule = ROLModInterop.getSolverEngineModule(part, engineID);
+            if (ROLModInterop.getSolverEngineModule(part, engineID) is ModuleEngines solverEnginesModule)
+            {
+                MethodInfo getter = ROLModInterop.getSolverEngineTempProperty().GetGetMethod();
 
-            if (solverEnginesModule == null)
-                return;
-
-            MethodInfo getter = ROLModInterop.getSolverEngineTempProperty().GetGetMethod();
-
-            getSolverChamberTemp = (Func<double>) Delegate.CreateDelegate(typeof(Func<double>), solverEnginesModule, getter);
-
-            useSolverEngines = true;
+                getSolverChamberTemp = (Func<double>) Delegate.CreateDelegate(typeof(Func<double>), solverEnginesModule, getter);
+            }
         }
 
         private void updateHeat()

--- a/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
+++ b/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 namespace ROLib
@@ -103,13 +104,7 @@ namespace ROLib
             engineModule = null;
             ModuleEngines[] engines = part.GetComponents<ModuleEngines>();
             int len = engines.Length;
-            for (int i = 0; i < len; i++)
-            {
-                if (engines[i].engineID == engineID)
-                {
-                    engineModule = engines[i];
-                }
-            }
+            engineModule = part.GetComponents<ModuleEngines>().FirstOrDefault(x => x.engineID == engineID);
             if (engineModule == null)
             {
                 MonoBehaviour.print("ERROR: Could not locate engine by ID: " + engineID + " for part: " + part + " for ROLAnimateEngineHeat.  This will cause errors during gameplay.  Setting engine to first engine module (if present)");
@@ -121,10 +116,9 @@ namespace ROLib
         {
             List<Renderer> renderers = new List<Renderer>();
             Transform[] animatedTransforms = part.transform.ROLFindChildren(meshName);
-            int len = animatedTransforms.Length;
-            for (int i = 0; i < len; i++)
+            foreach (var animatedTransform in animatedTransforms)
             {
-                renderers.AddRange(animatedTransforms[i].GetComponentsInChildren<Renderer>(false));
+                renderers.AddRange(animatedTransform.GetComponentsInChildren<Renderer>(false));
             }
             animatedRenderers = renderers.ToArray();
             if (animatedRenderers == null || animatedRenderers.Length == 0) { print("ERROR: Could not locate any emissive meshes for name: " + meshName); }
@@ -180,15 +174,14 @@ namespace ROLib
             if (animatedRenderers != null)
             {
                 bool rebuild = false;
-                int len = animatedRenderers.Length;
-                for (int i = 0; i < len; i++)
+                foreach(var renderer in animatedRenderers)
                 {
-                    if (animatedRenderers[i] == null)
+                    if (renderer == null)
                     {
                         rebuild = true;
                         continue;
                     }
-                    animatedRenderers[i].sharedMaterial.SetColor(shaderEmissiveID, emissiveColor);
+                    renderer.sharedMaterial.SetColor(shaderEmissiveID, emissiveColor);
                 }
                 if (rebuild)
                 {

--- a/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
+++ b/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -98,12 +99,14 @@ namespace ROLib
             locateEngineModule();
             if(ROLModInterop.IsSolverEnginesInstalled() && !useThrottle)
                 locateSolverEngines();
+            else if (!ROLModInterop.IsSolverEnginesInstalled() && !useThrottle && HighLogic.LoadedSceneIsFlight)
+                StartCoroutine(updateHeatCalc());
         }
 
         public void Update()
         {
             if (HighLogic.LoadedSceneIsFlight)
-                updateHeat();
+                updateHeatAnim();
         }
 
         private void locateEngineModule()
@@ -139,14 +142,12 @@ namespace ROLib
             }
         }
 
-        private void updateHeat()
+        private IEnumerator updateHeatCalc()
         {
-            if (engineModule == null) { return; }
-
-            float emissivePercent = 0f;
-
-            if (!useThrottle && !useSolverEngines)
+            while (true)
             {
+                yield return new WaitForFixedUpdate();
+
                 //add heat from engine
                 if (engineModule.EngineIgnited && !engineModule.flameout && engineModule.currentThrottle > 0)
                 {
@@ -164,7 +165,17 @@ namespace ROLib
                     currentHeat -= heatOut;
                 }
                 if (currentHeat > maxStoredHeat) { currentHeat = maxStoredHeat; }
+            }
+        }
 
+        private void updateHeatAnim()
+        {
+            if (engineModule == null) { return; }
+
+            float emissivePercent = 0f;
+
+            if (!useThrottle && !useSolverEngines)
+            {
                 float mhd = maxHeat - draperPoint;
                 float chd = currentHeat - draperPoint;
 

--- a/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
+++ b/Source/ROLib/Modules/ROLAnimateEngineHeat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -68,7 +68,6 @@ namespace ROLib
 
         public override void OnAwake()
         {
-            base.OnAwake();
             heatDissipationCurve.Add(0f, 0.2f);
             heatDissipationCurve.Add(1f, 1f);
 
@@ -89,27 +88,14 @@ namespace ROLib
 
         public override void OnStart(StartState state)
         {
-            base.OnStart(state);
-            initialize();
-        }
-
-        public void FixedUpdate()
-        {
-            if (!HighLogic.LoadedSceneIsFlight) { return; }
-            updateHeat();
-        }
-
-        private void initialize()
-        {
             locateAnimatedTransforms();
             locateEngineModule();
         }
 
-        public void reInitialize()
+        public void FixedUpdate()
         {
-            animatedRenderers = null;
-            engineModule = null;
-            initialize();
+            if (HighLogic.LoadedSceneIsFlight)
+                updateHeat();
         }
 
         private void locateEngineModule()

--- a/Source/ROLib/ROLib.csproj
+++ b/Source/ROLib/ROLib.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <None Include="Modules\ModuleROTAirstreamShield.bak" />
     <Compile Include="Modules\ModuleROSolar.cs" />
+    <Compile Include="Modules\ROLAnimateEngineHeat.cs" />
     <Compile Include="Modules\ROLDeployableEngine.cs" />
     <Compile Include="ROSolar\SolarTechLimit.cs" />
     <Compile Include="UI\DimensionWindow.cs" />


### PR DESCRIPTION
This Module is pretty much the same as the SSTU AnimateEngineHeat. For simulating heat, it uses a "fake" heat instead of the SolverEngines heat, which would require either SolverEnignes as a dependency, or acessing it via reflection. I modified the original module to also include a mode that directly takes the engine throttle as an input. The module has the advantage over the stock module that it doesn't require the part to have a heat animation, and instead changes the emissive material directly. This allow for better control over the emissive, and it is possible to change the RGB curves in config.

All credit goes to shadowmage45