### PR TITLE
Fix TL display in sandbox?

### DIFF
--- a/Source/ROLib/Modules/ModuleROSolar.cs
+++ b/Source/ROLib/Modules/ModuleROSolar.cs
@@ -351,8 +351,6 @@ namespace ROLib
 
         private void SetMaxTechLevel()
         {
-            if (HighLogic.CurrentGame.Mode != Game.Modes.CAREER)
-                maxTechLevel = 7;
 
             (Fields[nameof(TechLevel)].uiControlEditor as UI_FloatRange).maxValue = maxTechLevel;
             if (HighLogic.LoadedSceneIsEditor && TechLevel < 0)


### PR DESCRIPTION
Don't bother to explicitly define TL in sandbox. Instead rely on upgrades being automatically unlocked, preventing slider from getting stuck at TL7.