### PR TITLE
Support RP-1 integration

### DIFF
--- a/Source/ROLib/Modules/ModuleROSolar.cs
+++ b/Source/ROLib/Modules/ModuleROSolar.cs
@@ -105,6 +105,7 @@ namespace ROLib
 
         ModelDefinitionLayoutOptions[] coreDefs;
         private SolarTechLimit stl;
+        private int unlockedMaxTechLevel = 0;
 
         // Previous length/width/scale values for change detection
         private float prevLength = -1;
@@ -242,6 +243,7 @@ namespace ROLib
 
         internal void ModelChangedHandler(bool pushNodes)
         {
+            ApplyTLColoring();
             stl = SolarTechLimit.GetTechLevel(techLevel);
             retractable = stl.retractable && solarPanelType != "static";
             useRaycastForTrackingDot = true;
@@ -358,16 +360,54 @@ namespace ROLib
 
         private void SetMaxTechLevel()
         {
-
-            (Fields[nameof(TechLevel)].uiControlEditor as UI_FloatRange).maxValue = maxTechLevel;
-            if (HighLogic.LoadedSceneIsEditor && TechLevel < 0)
+            unlockedMaxTechLevel = maxTechLevel;
+            if (ROLModInterop.IsRP1Installed())
             {
-                TechLevel = maxTechLevel;
+                // For RP-1 purposes, allow selection of all TLs. Validation will prevent construction of TL above max, anyway.
+                maxTechLevel = SolarTechLimit.maxTL;
+            }
+            (Fields[nameof(TechLevel)].uiControlEditor as UI_FloatRange).maxValue = maxTechLevel;
+            
+            if (HighLogic.LoadedSceneIsEditor && (TechLevel < 0 || TechLevel > maxTechLevel))
+            {
+                // If the user loads a craft with TL > unlocked, clamp it back down.
+                TechLevel = maxTechLevel;           
+                if (ROLModInterop.IsRP1Installed()) // RP-1 
+                    TechLevel = SolarTechLimit.GetBestUnlockableTechLevel();
             }
             if (maxTechLevel == 0)
             {
                 Fields[nameof(TechLevel)].guiActiveEditor = false;
                 Fields[nameof(tlText)].guiActiveEditor = true;
+            }
+        }
+
+        private void UpdateMaxTechLevelInUI()
+        {
+            if (Fields[nameof(TechLevel)].uiControlEditor is UI_FloatRange fr)
+            {
+                fr.maxValue = maxTechLevel;
+            }
+            if (maxTechLevel > 0)
+            {
+                Fields[nameof(TechLevel)].guiActiveEditor = true;
+                Fields[nameof(tlText)].guiActiveEditor = false;
+            }
+            else
+            {
+                Fields[nameof(TechLevel)].guiActiveEditor = false;
+                Fields[nameof(tlText)].guiActiveEditor = true;
+            }
+        }
+
+        private void ApplyTLColoring()
+        {
+            if (HighLogic.LoadedSceneIsEditor)
+            {
+                int maxPurchasableTechLevel = SolarTechLimit.GetBestUnlockableTechLevel();
+                BaseField f = Fields[nameof(TechLevel)];
+                f.guiFormat = techLevel > maxPurchasableTechLevel ? "'<color=orange>'#'</color>'" : (techLevel > unlockedMaxTechLevel ? "'<color=yellow>'#'</color>'" : "N0");
+                f.guiName = techLevel > maxPurchasableTechLevel ? "<color=orange>Tech Level</color>" : (techLevel > unlockedMaxTechLevel ? "<color=yellow>Tech Level</color>" : "Tech Level");
             }
         }
 
@@ -559,5 +599,94 @@ namespace ROLib
         }
 
         #endregion Custom Methods
+
+        #region RP-1 Integration
+        /// <summary>
+        /// Called from RP-1 VesselBuildValidator
+        /// </summary>
+        /// <param name="validationError"></param>
+        /// <param name="canBeResolved"></param>
+        /// <param name="costToResolve"></param>
+        /// <returns></returns>
+        public virtual bool Validate(out string validationError, out bool canBeResolved, out float costToResolve, out string techToResolve)
+        {
+            validationError = null;
+            canBeResolved = false;
+            costToResolve = 0;
+            techToResolve = string.Empty;
+
+            PartUpgradeHandler.Upgrade upgd = SolarTechLimit.GetPartUpgradeForTL(techLevel);
+
+            if (PartUpgradeManager.Handler.IsUnlocked(upgd.name))
+            {
+                return true;
+            }
+            else if (PartUpgradeManager.Handler.IsAvailableToUnlock(upgd.name))
+            {
+                canBeResolved = true;
+                costToResolve = upgd.entryCost;
+                validationError = $"purchase {upgd.title}";
+            }
+            else
+            {
+                techToResolve = upgd.techRequired;
+                validationError = $"unlock tech {ResearchAndDevelopment.GetTechnologyTitle(upgd.techRequired)}";
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Called from RP-1 VesselBuildValidator
+        /// </summary>
+        /// <returns></returns>
+        public virtual bool ResolveValidationError()
+        {
+            PartUpgradeHandler.Upgrade upgd = SolarTechLimit.GetPartUpgradeForTL(techLevel);
+            if (upgd == null)
+                return false;
+            return PurchaseConfig(upgd);
+        }
+
+        /// <summary>
+        /// NOTE: Harmony-patched from RP-1 to factor in unlock credit.
+        /// </summary>
+        /// <param name="cost"></param>
+        /// <returns></returns>
+        private static bool CanAffordEntryCost(float cost)
+        {
+            CurrencyModifierQuery cmq = CurrencyModifierQuery.RunQuery(TransactionReasons.RnDPartPurchase, -cost, 0, 0);
+            return cmq.CanAfford();
+        }
+
+        private static bool PurchaseConfig(PartUpgradeHandler.Upgrade upgd)
+        {
+            if (!CanAffordEntryCost(upgd.entryCost))
+                return false;
+            PartUpgradeManager.Handler.SetUnlocked(upgd.name, true);
+            GameEvents.OnPartUpgradePurchased.Fire(upgd);
+            return true;
+        }
+
+        /// <summary>
+        /// Handles TL PartUpgrade getting purchased in Editor scene
+        /// </summary>
+        /// <param name="upgd"></param>
+        private void OnPartUpgradePurchased(PartUpgradeHandler.Upgrade upgd)
+        {
+            if (!upgd.name.StartsWith("solarTL")) return;
+            for (int i = SolarTechLimit.maxTL; i > unlockedMaxTechLevel; --i) 
+            {
+                if (upgd.name == SolarTechLimit.GetPartUpgradeForTL(i).name) 
+                {
+                    unlockedMaxTechLevel = i;
+                    if (!ROLModInterop.IsRP1Installed()) maxTechLevel = i;
+                    UpdateMaxTechLevelInUI();
+                    ApplyTLColoring();
+                    break;
+                }
+            }
+        }
+        #endregion
     }
 }

--- a/Source/ROLib/Modules/ModuleROSolar.cs
+++ b/Source/ROLib/Modules/ModuleROSolar.cs
@@ -361,7 +361,7 @@ namespace ROLib
         private void SetMaxTechLevel()
         {
             unlockedMaxTechLevel = maxTechLevel;
-            if (ROLModInterop.IsRP1Installed())
+            if (ROUtils.ModUtils.IsRP1Installed)
             {
                 // For RP-1 purposes, allow selection of all TLs. Validation will prevent construction of TL above max, anyway.
                 maxTechLevel = SolarTechLimit.maxTL;
@@ -372,7 +372,7 @@ namespace ROLib
             {
                 // If the user loads a craft with TL > unlocked, clamp it back down.
                 TechLevel = maxTechLevel;           
-                if (ROLModInterop.IsRP1Installed()) // RP-1 
+                if (ROUtils.ModUtils.IsRP1Installed) // RP-1 
                     TechLevel = SolarTechLimit.GetBestUnlockableTechLevel();
             }
             if (maxTechLevel == 0)
@@ -680,7 +680,7 @@ namespace ROLib
                 if (upgd.name == SolarTechLimit.GetPartUpgradeForTL(i).name) 
                 {
                     unlockedMaxTechLevel = i;
-                    if (!ROLModInterop.IsRP1Installed()) maxTechLevel = i;
+                    if (!ROUtils.ModUtils.IsRP1Installed) maxTechLevel = i;
                     UpdateMaxTechLevelInUI();
                     ApplyTLColoring();
                     break;

--- a/Source/ROLib/ROSolar/SolarTechLimit.cs
+++ b/Source/ROLib/ROSolar/SolarTechLimit.cs
@@ -27,7 +27,7 @@ namespace ROLib
         public static bool isInitialized = false;
 
         private static readonly Dictionary<int, SolarTechLimit> allTL = new Dictionary<int, SolarTechLimit>();
-        private static int maxTL = -1;
+        public static int maxTL { get; private set; } = -1;
         private const string modTag = "[ModuleROSolar.SolarTechLimit]";
 
         public SolarTechLimit() { }
@@ -67,6 +67,24 @@ namespace ROLib
                 return info;
             }
             return allTL[0];
+        }
+
+        public static PartUpgradeHandler.Upgrade GetPartUpgradeForTL(int lvl)
+        {
+            if (lvl < 0 || lvl > maxTL) return null;
+            string name = $"solarTL{lvl}";
+            return PartUpgradeManager.Handler.GetUpgrade(name);
+        }
+
+        public static int GetBestUnlockableTechLevel()
+        {
+            for (int i = maxTL; i >= 0; --i)
+            { 
+                string name = $"solarTL{i}";
+                if (PartUpgradeManager.Handler.IsUnlocked(name) || PartUpgradeManager.Handler.IsAvailableToUnlock(name)) 
+                    return i;
+            }
+            return 0;
         }
     }
 }

--- a/Source/ROLib/Utils/ROLModInterop.cs
+++ b/Source/ROLib/Utils/ROLModInterop.cs
@@ -10,7 +10,7 @@ namespace ROLib
     public static class ROLModInterop
     {
         private static bool initialized = false;
-        private static Assembly FARAssembly, RFAssembly, MFTAssembly, SolverEnginesAssembly, RP0Assembly;
+        private static Assembly FARAssembly, RFAssembly, MFTAssembly, SolverEnginesAssembly;
         private static MethodInfo MFTChangeTotalVolumeMI, MFTCalculateMassMI;
         private static PropertyInfo SolverEnginesTempPI;
         private static Type MFTType, SolverEngineType;
@@ -119,7 +119,6 @@ namespace ROLib
             RFAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "RealFuels")?.assembly;
             MFTAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "modularFuelTanks")?.assembly;
             SolverEnginesAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "SolverEngines")?.assembly;
-            RP0Assembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "RP0")?.assembly;
             if (RFAssembly is Assembly || MFTAssembly is Assembly)
             {
                 string targ = RFAssembly is Assembly ? "RealFuels.Tanks.ModuleFuelTanks,RealFuels" : "RealFuels.Tanks.ModuleFuelTanks,modularFuelTanks";
@@ -156,12 +155,6 @@ namespace ROLib
         {
             if (!initialized) Init();
             return SolverEnginesAssembly is Assembly;
-        }
-
-        public static bool IsRP1Installed()
-        { 
-            if (!initialized) Init();
-            return RP0Assembly is Assembly;
         }
 
         public static void UpdatePartResourceDisplay(Part part)

--- a/Source/ROLib/Utils/ROLModInterop.cs
+++ b/Source/ROLib/Utils/ROLModInterop.cs
@@ -10,7 +10,7 @@ namespace ROLib
     public static class ROLModInterop
     {
         private static bool initialized = false;
-        private static Assembly FARAssembly, RFAssembly, MFTAssembly, SolverEnginesAssembly;
+        private static Assembly FARAssembly, RFAssembly, MFTAssembly, SolverEnginesAssembly, RP0Assembly;
         private static MethodInfo MFTChangeTotalVolumeMI, MFTCalculateMassMI;
         private static PropertyInfo SolverEnginesTempPI;
         private static Type MFTType, SolverEngineType;
@@ -119,6 +119,7 @@ namespace ROLib
             RFAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "RealFuels")?.assembly;
             MFTAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "modularFuelTanks")?.assembly;
             SolverEnginesAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "SolverEngines")?.assembly;
+            RP0Assembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name == "RP0")?.assembly;
             if (RFAssembly is Assembly || MFTAssembly is Assembly)
             {
                 string targ = RFAssembly is Assembly ? "RealFuels.Tanks.ModuleFuelTanks,RealFuels" : "RealFuels.Tanks.ModuleFuelTanks,modularFuelTanks";
@@ -155,6 +156,12 @@ namespace ROLib
         {
             if (!initialized) Init();
             return SolverEnginesAssembly is Assembly;
+        }
+
+        public static bool IsRP1Installed()
+        { 
+            if (!initialized) Init();
+            return RP0Assembly is Assembly;
         }
 
         public static void UpdatePartResourceDisplay(Part part)


### PR DESCRIPTION
This PR adds part validation for RP-1 purposes (Validate, and ResolveValidationError). Code for these function is drawn from RealAntennas' implementation of these functions, which contains the expected behaviour. (fully allow if unlocked, if researched but not unlocked let the player buy it, if not researched fail)

In addition, the TechLevel slider now behaves similarly to the RA TechLevel slider when RP-1 is detected. All levels are selectable, but levels that are researched but not purchased change the TL text colour to yellow, and levels that are not researched change the text colour to orange. Finally, the default TL becomes the maximum researched TL (that is possibly not yet purchased).

For non-RP-1, behaviour remains as before, except solar panels with higher tech level than the maximum purchased (due to loading a craft, for instance) will be clamped down to the maximum purchased TL.